### PR TITLE
Fix mcp_hlf_tool stdio run line

### DIFF
--- a/fabric-mcp/mcp_hlf_tool.py
+++ b/fabric-mcp/mcp_hlf_tool.py
@@ -124,4 +124,4 @@ require github.com/hyperledger/fabric-contract-api-go v1.1.0
         return {"status": "error", "message": str(e)}
 
 if __name__ == "__main__":
-    mcp.run(transport='stdio')
+    mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary
- fix missing newline in `mcp_hlf_tool.py`
- run FastMCP with the correct quotation style

## Testing
- `python3 -m py_compile fabric-mcp/mcp_hlf_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_6840669a128c83279e8f96c0aca31de7