### PR TITLE
Add requirements file for fabric-mcp

### DIFF
--- a/fabric-mcp/README.md
+++ b/fabric-mcp/README.md
@@ -20,8 +20,7 @@ A Python-based MCP (Multi-Chain Platform) tool for automating and orchestrating 
 2. **Install Python 3.9+**
 3. **Install dependencies:**
    ```sh
-   pip install httpx
-   # (and any other requirements for your MCP/agent framework)
+   pip install -r requirements.txt
    ```
 4. **Ensure Go is installed** (for chaincode writing):
    ```sh

--- a/fabric-mcp/requirements.txt
+++ b/fabric-mcp/requirements.txt
@@ -1,0 +1,3 @@
+httpx
+mcp
+


### PR DESCRIPTION
## Summary
- add `fabric-mcp/requirements.txt`
- document dependency installation with requirements file in `fabric-mcp/README.md`

## Testing
- `python3 -m py_compile fabric-mcp/mcp_hlf_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_684066a0b75083279175acba5acb2239